### PR TITLE
typearg qol for waitforchild

### DIFF
--- a/include/customDefinitions.d.ts
+++ b/include/customDefinitions.d.ts
@@ -485,6 +485,7 @@ interface Instance {
 	FindFirstChild(this: Instance, childName: string | number, recursive?: boolean): Instance | undefined;
 	WaitForChild(this: Instance, childName: string | number): Instance;
 	WaitForChild(this: Instance, childName: string | number, timeOut: number): Instance | undefined;
+	WaitForChild<T extends Instance>(this: Instance, childName: string | number): T;
 	IsA<T extends keyof Instances>(this: Instance, className: T): this is Instances[T];
 	FindFirstAncestorWhichIsA<T extends keyof Instances>(this: Instance, className: T): Instances[T] | undefined;
 	FindFirstChildWhichIsA<T extends keyof Instances>(


### PR DESCRIPTION
Why use the 'as' when you can directly pass the typearg?
```ts
const PlayerGui = LocalPlayer.WaitForChild("PlayerGui") as PlayerGui;
```

Much cleaner:
```ts
const PlayerGui = LocalPlayer.WaitForChild<PlayerGui>("PlayerGui");
```